### PR TITLE
Fix Jenkins Execute Shell able virtualenvWrapper

### DIFF
--- a/virtualenvwrapper.sh
+++ b/virtualenvwrapper.sh
@@ -690,8 +690,8 @@ function workon {
     # Deactivate any current environment "destructively"
     # before switching so we use our override function,
     # if it exists.
-    type deactivate >/dev/null 2>&1
-    if [ $? -eq 0 ]
+    ret=$(type deactivate >/dev/null 2>&1 && echo 0 || echo 1)
+    if [ $ret -eq 0 ]
     then
         deactivate
         unset -f deactivate >/dev/null 2>&1


### PR DESCRIPTION
### Issue
- can't run jenkins with virtualenvwrapper
- ![image](https://user-images.githubusercontent.com/10006290/67273547-a0018900-f4f9-11e9-9f7c-87655666e66f.png)

### Cause & Solve
- Jenkins define `failed` is any function return not success, example `$?` is not return `0`
- So, I try `&& {IS_TRUE} || {IS_FALSE}` code than using `$?` code

### Result
- `virtualenvWrapper` is run on jenkins `execute shell` paragraph 👍 
